### PR TITLE
 Use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ outputs:
   output-string:
       description: "The transformed string"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
## what
* Use node20

## why
* Node16 is deprecated for Github Actions